### PR TITLE
fix: match Element type check in _restoreNodeVisibility to _hideNode

### DIFF
--- a/projects/flo/editor/editor.component.ts
+++ b/projects/flo/editor/editor.component.ts
@@ -642,7 +642,7 @@ export class EditorComponent implements OnInit, OnDestroy {
     for (let i = 0; i < domNode.childNodes.length; i++) {
       if (j < oldVisibility.children.length) {
         let node = domNode.children.item(i);
-        if (node instanceof Element) {
+        if (node instanceof HTMLElement) {
           this._restoreNodeVisibility(node as any, oldVisibility.children[j++]);
         }
       }


### PR DESCRIPTION
`_hideNode()` uses `instanceof HTMLElement` when iterating children to
save visibility state. `_restoreNodeVisibility()` uses `instanceof Element`,
causing counter mismatch when SVG elements are present. This makes nodes
with dynamically generated SVG content remain invisible after drag.

Change `_restoreNodeVisibility()` to use `instanceof HTMLElement` to match
`_hideNode()` behavior, ensuring counter stays synchronized regardless of
SVG element count.

Signed-off-by: Max Brauer <mbrauer@vmware.com>
